### PR TITLE
Corrected spelling of 'position' in error message.

### DIFF
--- a/hybrids/jscript/xpath.bat
+++ b/hybrids/jscript/xpath.bat
@@ -63,7 +63,7 @@ if(!loaded){
 	WScript.Echo("");
 	WScript.Echo("Error Code:"+objDoc.parseError.errorCode);
 	WScript.Echo("");
-	WScript.Echo("Line:"+objDoc.parseError.line+" Posotion:"+objDoc.parseError.filepos);
+	WScript.Echo("Line:"+objDoc.parseError.line+" Position:"+objDoc.parseError.filepos);
 	WScript.Echo("");
 	WScript.Echo("Reason:"+objDoc.parseError.reason);
 	WScript.Echo("");


### PR DESCRIPTION
Corrected the misspelling of 'position' (was 'posotion') in the error message that is displayed when an error occurs while parsing the XML document.