### PR TITLE
Fixed masking problem

### DIFF
--- a/hybrids/.net/FileTimeFilerJS.bat
+++ b/hybrids/.net/FileTimeFilerJS.bat
@@ -248,7 +248,7 @@ if (min_date > max_date) {
 
 
 function listItems(funct,getFunct){
-	var files:String[]=funct(directory,"*",System.IO.SearchOption.AllDirectories);
+	var files:String[]=funct(directory,mask,System.IO.SearchOption.AllDirectories);
 	for (var f=0;f<files.length;f++){
 		if (getFunct(files[f]).Ticks >= min_date && getFunct(files[f]).Ticks <= max_date){
 			


### PR DESCRIPTION
Unfortunately, original code doesn't filter undesired files and folders. The parameter "-mask" does not work. This small fix solves the problem.