### PR TITLE
Update say.bat to allow multiple words

### DIFF
--- a/hybrids/mshta/say.bat
+++ b/hybrids/mshta/say.bat
@@ -1,6 +1,6 @@
 :speak
 @echo off 
 setlocal enableDelayedExpansion
-set "toSay=%~1"
+set "toSay=%*"
 mshta "javascript:code(close((v=new ActiveXObject('SAPI.SpVoice')).GetVoices()&&v.Speak('!toSay!')))"
 endLocal


### PR DESCRIPTION
This allows multiple parameters as words of a sentence, rather than a single word